### PR TITLE
[Test] Document memorization API contract

### DIFF
--- a/backend/tests/test_api_contract.py
+++ b/backend/tests/test_api_contract.py
@@ -1,0 +1,29 @@
+from app.services.question_service import QuestionService
+from app.services.stats_service import StatsService
+
+
+def test_question_detail_hides_answers_by_default() -> None:
+    question = QuestionService().list_questions(limit=1)[0]
+
+    hidden = QuestionService().get_question(question.questionId)
+
+    assert hidden.questionId == question.questionId
+    assert hidden.answers == []
+    assert hidden.aliases == []
+    assert hidden.keywords == []
+
+
+def test_question_detail_can_include_answers_for_memorization_helpers() -> None:
+    question = QuestionService().list_questions(limit=1)[0]
+
+    shown = QuestionService().get_question(question.questionId, include_answer=True)
+
+    assert shown.questionId == question.questionId
+    assert shown.answers
+    assert shown.keywords
+
+
+def test_weakness_stats_support_repeat_study_flow() -> None:
+    payload = StatsService().get_weakness_stats()
+
+    assert set(payload.model_dump()) == {"weakUnits", "weakQuestions", "weakKeywords"}


### PR DESCRIPTION
## 🧩 PR 제목
[Test] Document memorization API contract

---

## 📌 작업 내용 (What)
- 암기 보조 기능에 필요한 기존 백엔드 API 계약을 테스트로 고정
- `GET /api/questions/{questionId}` 기본 응답이 정답을 숨기는지 검증
- `includeAnswer=true`가 정답 공개 흐름을 지원하는지 검증
- `GET /api/stats/weakness`가 반복 학습용 약점 정보 엔드포인트로 동작하는지 검증

---

## 🎯 작업 이유 (Why)
- 프론트의 암기 보조 UI가 별도 백엔드 확장 없이 기존 API 조합만으로 동작 가능한지 확인하기 위해
- 불필요한 백엔드 변경을 피하고 현재 계약을 명확히 문서화하기 위해

---

## 🔧 변경 사항 (How)
- `/backend/tests/test_api_contract.py`를 추가해 서비스 레벨 계약을 검증
- 기존 `QuestionService`와 `StatsService`의 동작을 직접 확인해 API가 이미 충분하다는 점을 고정
- 새로운 백엔드 API는 추가하지 않음

---

## 📁 변경 파일
- `backend/tests/test_api_contract.py`

---

## 🧪 테스트 방법
1. `backend/.venv/bin/python -c "from app.services.question_service import QuestionService; from app.services.stats_service import StatsService; ..."`
2. `GET /api/questions/{questionId}`의 기본 숨김 동작 확인
3. `GET /api/questions/{questionId}?includeAnswer=true`의 정답 공개 동작 확인
4. `GET /api/stats/weakness`의 응답 키 확인

---

## ⚠️ 영향 범위
- 백엔드 API 동작 자체는 변경하지 않음
- 프론트의 암기 보조 UI가 활용할 수 있는 기존 계약을 명시적으로 검증함

---

## 🔥 리뷰 포인트
- 새 API를 만들지 않고도 요구사항을 충족하는 판단이 타당한지
- 테스트가 현재 계약을 충분히 설명하는지

---

## 📸 결과 (선택)
- `backend-contract-ok`

---

## 🔗 관련 이슈
Closes #15

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료
