### PR TITLE
[Feature] 암기 보조 UI와 뒤로가기 동선 추가

### DIFF
--- a/frontend/src/app/exam/[examId]/ExamClient.tsx
+++ b/frontend/src/app/exam/[examId]/ExamClient.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 
@@ -39,22 +38,16 @@ export function ExamClient({ exam }: Props) {
 
   return (
     <div className="stack">
-      <section className="panel stack">
+      <section className="panel stack exam-status">
         <div className="actions">
-          <div className="badge">답안 작성 {answeredCount} / {exam.questions.length}</div>
+          <div className="badge">
+            답안 작성 {answeredCount} / {exam.questions.length}
+          </div>
           <div className="badge secondary-badge">미작성 {unansweredCount}</div>
         </div>
         <p className="muted">
           빈칸으로 제출해도 채점은 가능하지만, 실전처럼 끝까지 적어보는 쪽이 더 좋습니다.
         </p>
-        <div className="actions">
-          <Link className="button secondary" href="/exam">
-            다른 시험 만들기
-          </Link>
-          <button onClick={handleSubmit} disabled={isSubmitting}>
-            {isSubmitting ? "채점 중..." : "제출하고 채점 보기"}
-          </button>
-        </div>
         {error ? <p className="error-text">{error}</p> : null}
       </section>
 
@@ -76,6 +69,18 @@ export function ExamClient({ exam }: Props) {
           />
         </QuestionCard>
       ))}
+
+      <section className="panel stack submit-panel">
+        <h2>제출하기</h2>
+        <p className="muted">
+          다 적었으면 아래 버튼으로 제출하세요. 채점 결과와 오답노트는 제출 후 바로 이어집니다.
+        </p>
+        <div className="actions">
+          <button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "채점 중..." : "제출하고 채점 보기"}
+          </button>
+        </div>
+      </section>
     </div>
   );
 }

--- a/frontend/src/app/exam/[examId]/page.tsx
+++ b/frontend/src/app/exam/[examId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { BackLink } from "@/components/BackLink";
 import { ExamClient } from "@/app/exam/[examId]/ExamClient";
 import { getExam } from "@/lib/api";
 
@@ -22,6 +23,7 @@ export default async function ExamDetailPage({ params }: Props) {
             {exam.parts.length > 0 ? ` / ${exam.parts.join(", ")}` : ""}
           </p>
           <div className="actions">
+            <BackLink fallbackHref="/exam" />
             <Link className="button secondary" href="/exam">
               시험 설정으로 돌아가기
             </Link>

--- a/frontend/src/app/exam/page.tsx
+++ b/frontend/src/app/exam/page.tsx
@@ -1,3 +1,4 @@
+import { BackLink } from "@/components/BackLink";
 import { ExamSetupForm } from "@/components/ExamSetupForm";
 import { getUnits } from "@/lib/api";
 
@@ -11,6 +12,9 @@ export default async function ExamPage() {
           <div className="badge">시험 모드</div>
           <h1>범위를 고른 뒤 시험을 만들고, 한 번에 제출해서 결과를 확인합니다.</h1>
           <p className="muted">자동으로 생성하지 않고, 지금부터 풀 시험을 직접 선택해서 시작합니다.</p>
+          <div className="actions">
+            <BackLink fallbackHref="/" />
+          </div>
         </section>
 
         <section className="grid columns-2">

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -105,6 +105,13 @@ button.secondary {
   padding: 20px;
 }
 
+.study-answer {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(138, 90, 50, 0.08);
+  border: 1px solid rgba(138, 90, 50, 0.15);
+}
+
 .muted {
   color: var(--muted);
 }
@@ -136,6 +143,16 @@ textarea {
   background: white;
   color: var(--text);
   font: inherit;
+}
+
+.submit-panel {
+  margin-top: 8px;
+}
+
+.exam-status {
+  position: sticky;
+  top: 16px;
+  z-index: 1;
 }
 
 .checkbox-row {
@@ -181,5 +198,9 @@ ul {
   .page {
     width: min(100% - 20px, 1080px);
     padding-top: 24px;
+  }
+
+  .exam-status {
+    position: static;
   }
 }

--- a/frontend/src/app/results/[examId]/page.tsx
+++ b/frontend/src/app/results/[examId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { BackLink } from "@/components/BackLink";
 import { ResultSummary } from "@/components/ResultSummary";
 import { getExamResult } from "@/lib/api";
 
@@ -18,6 +19,7 @@ export default async function ResultPage({ params }: Props) {
           <div className="badge">채점 결과</div>
           <h1>맞은 부분과 빠진 키워드를 한눈에 봅니다.</h1>
           <div className="actions">
+            <BackLink fallbackHref={`/exam/${examId}`} />
             <Link className="button secondary" href="/exam">
               다른 시험 만들기
             </Link>

--- a/frontend/src/app/study/page.tsx
+++ b/frontend/src/app/study/page.tsx
@@ -1,4 +1,5 @@
-import { QuestionCard } from "@/components/QuestionCard";
+import { BackLink } from "@/components/BackLink";
+import { StudyDeck } from "@/components/StudyDeck";
 import { getQuestions } from "@/lib/api";
 
 export default async function StudyPage() {
@@ -10,24 +11,13 @@ export default async function StudyPage() {
         <section className="hero stack">
           <div className="badge">학습 모드</div>
           <h1>문제를 보고 먼저 떠올린 뒤, 바로 정답을 확인합니다.</h1>
-          <p className="muted">초기 버전이라 정답을 함께 보여주고, 이후에는 가림/오답노트 기능을 추가하면 됩니다.</p>
+          <p className="muted">정답을 가렸다가 펼치고, 외운 문제는 숨기면서 반복 회상할 수 있습니다.</p>
+          <div className="actions">
+            <BackLink fallbackHref="/" />
+          </div>
         </section>
 
-        <section className="grid">
-          {questions.map((question, index) => (
-            <QuestionCard
-              key={question.questionId}
-              index={index}
-              prompts={question.prompts}
-              meta={`${question.unitId} / ${question.part} / ${question.type}`}
-            >
-              <div className="panel">
-                <strong>정답</strong>
-                <p>{question.answers.join(" / ")}</p>
-              </div>
-            </QuestionCard>
-          ))}
-        </section>
+        <StudyDeck questions={questions} />
       </div>
     </main>
   );

--- a/frontend/src/app/wrong-notes/page.tsx
+++ b/frontend/src/app/wrong-notes/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 
+import { BackLink } from "@/components/BackLink";
 import { WrongNotesClient } from "@/components/WrongNotesClient";
 
 export default function WrongNotesPage() {
@@ -10,6 +11,7 @@ export default function WrongNotesPage() {
           <div className="badge">오답노트</div>
           <h1>틀린 문제를 모아두고 다시 반복해서 확인합니다.</h1>
           <div className="actions">
+            <BackLink fallbackHref="/" />
             <Link className="button secondary" href="/exam">
               새 시험 만들기
             </Link>

--- a/frontend/src/components/BackLink.tsx
+++ b/frontend/src/components/BackLink.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import type { MouseEvent } from "react";
+
+type Props = {
+  fallbackHref: string;
+  label?: string;
+  className?: string;
+};
+
+export function BackLink({ fallbackHref, label = "뒤로가기", className = "button secondary" }: Props) {
+  const router = useRouter();
+
+  function handleClick(event: MouseEvent<HTMLAnchorElement>) {
+    event.preventDefault();
+
+    if (typeof window !== "undefined" && document.referrer.startsWith(window.location.origin)) {
+      router.back();
+      return;
+    }
+
+    router.push(fallbackHref as never);
+  }
+
+  return (
+    <Link className={className} href={fallbackHref as never} onClick={handleClick}>
+      {label}
+    </Link>
+  );
+}

--- a/frontend/src/components/StudyDeck.tsx
+++ b/frontend/src/components/StudyDeck.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+
+import { QuestionCard } from "@/components/QuestionCard";
+import type { QuestionDetail } from "@/lib/types";
+
+type Props = {
+  questions: QuestionDetail[];
+};
+
+export function StudyDeck({ questions }: Props) {
+  const [revealedIds, setRevealedIds] = useState<Record<string, boolean>>({});
+  const [rememberedIds, setRememberedIds] = useState<Record<string, boolean>>({});
+  const [hideRemembered, setHideRemembered] = useState(true);
+
+  const rememberedCount = questions.filter((question) => rememberedIds[question.questionId]).length;
+  const remainingCount = questions.length - rememberedCount;
+  const visibleQuestions = hideRemembered
+    ? questions.filter((question) => !rememberedIds[question.questionId])
+    : questions;
+
+  function toggleAnswer(questionId: string) {
+    setRevealedIds((current) => ({
+      ...current,
+      [questionId]: !current[questionId]
+    }));
+  }
+
+  function toggleRemembered(questionId: string) {
+    setRememberedIds((current) => ({
+      ...current,
+      [questionId]: !current[questionId]
+    }));
+  }
+
+  function resetSession() {
+    setRevealedIds({});
+    setRememberedIds({});
+    setHideRemembered(true);
+  }
+
+  return (
+    <div className="stack">
+      <section className="panel stack">
+        <div className="actions">
+          <div className="badge">전체 {questions.length}</div>
+          <div className="badge secondary-badge">외운 문제 {rememberedCount}</div>
+          <div className="badge secondary-badge">다시 볼 문제 {remainingCount}</div>
+        </div>
+        <label className="checkbox-row">
+          <input
+            checked={hideRemembered}
+            type="checkbox"
+            onChange={(event) => setHideRemembered(event.target.checked)}
+          />
+          <span>외운 문제는 목록에서 숨기기</span>
+        </label>
+        <div className="actions">
+          <button className="secondary" type="button" onClick={resetSession}>
+            다시 시작하기
+          </button>
+        </div>
+      </section>
+
+      {visibleQuestions.length === 0 ? (
+        <section className="panel stack">
+          <h2>모든 문제를 외웠습니다.</h2>
+          <p className="muted">외운 문제 숨기기를 끄면 다시 전체 목록을 볼 수 있습니다.</p>
+        </section>
+      ) : null}
+
+      {visibleQuestions.map((question, index) => {
+        const isRevealed = revealedIds[question.questionId] ?? false;
+        const isRemembered = rememberedIds[question.questionId] ?? false;
+
+        return (
+          <QuestionCard
+            key={question.questionId}
+            index={index}
+            prompts={question.prompts}
+            meta={`${question.unitId} / ${question.part} / ${question.type}`}
+          >
+            <div className="stack">
+              {isRevealed ? (
+                <div className="study-answer">
+                  <strong>정답</strong>
+                  <p>{question.answers.join(" / ")}</p>
+                </div>
+              ) : (
+                <p className="muted">답을 먼저 떠올려 보고, 필요할 때만 정답을 확인하세요.</p>
+              )}
+              <div className="actions">
+                <button className="secondary" type="button" onClick={() => toggleAnswer(question.questionId)}>
+                  {isRevealed ? "정답 숨기기" : "정답 보기"}
+                </button>
+                <button
+                  type="button"
+                  className={isRemembered ? "secondary" : undefined}
+                  onClick={() => toggleRemembered(question.questionId)}
+                >
+                  {isRemembered ? "다시 볼래요" : "외웠어요"}
+                </button>
+              </div>
+            </div>
+          </QuestionCard>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] 암기 보조 UI와 뒤로가기 동선 추가

---

## 📌 작업 내용 (What)
- 학습 화면에 정답 가리기/보기와 외운 문제 숨기기 기능을 추가했습니다.
- 주요 메뉴와 결과 화면에 뒤로가기 동선을 넣었습니다.
- 시험 풀이 화면에서 제출 버튼을 카드 목록 아래로 내려 배치했습니다.

---

## 🎯 작업 이유 (Why)
- 사용자가 문제를 반복해서 외우는 흐름이 필요했습니다.
- 각 화면에서 이전 화면으로 돌아가는 경로가 없어 탐색이 불편했습니다.
- 시험 제출 버튼이 상단에 있어 풀이 흐름과 맞지 않았습니다.

---

## 🔧 변경 사항 (How)
- `BackLink` 공통 컴포넌트를 만들어 히스토리 기반 뒤로가기와 안전한 fallback 경로를 함께 지원했습니다.
- `StudyDeck`를 추가해 정답 표시 토글, 외운 문제 숨기기, 다시 보기 상태를 제공했습니다.
- 시험 화면의 제출 액션을 목록 하단으로 이동하고, 결과/오답노트/시험 설정 화면에 뒤로가기를 배치했습니다.

---

## 📁 변경 파일
- `frontend/src/components/BackLink.tsx`
- `frontend/src/components/StudyDeck.tsx`
- `frontend/src/app/study/page.tsx`
- `frontend/src/app/exam/page.tsx`
- `frontend/src/app/exam/[examId]/page.tsx`
- `frontend/src/app/exam/[examId]/ExamClient.tsx`
- `frontend/src/app/results/[examId]/page.tsx`
- `frontend/src/app/wrong-notes/page.tsx`
- `frontend/src/app/globals.css`

---

## 🧪 테스트 방법
1. `cd /Users/inchoi/prepareExam/frontend`
2. `npm run build`
3. 기대 결과: TypeScript 타입 체크와 빌드가 성공한다.

---

## ⚠️ 영향 범위
- `frontend` 화면 흐름에만 영향을 줍니다.
- 백엔드 API 변경은 없습니다.
- 기존 시험 생성/제출 API 호출 방식은 유지됩니다.

---

## 🔥 리뷰 포인트
- 히스토리 기반 뒤로가기와 fallback 경로가 의도대로 동작하는지 봐주세요.
- 학습 화면의 외운 문제 숨기기 동작이 반복 회상에 적절한지 확인해 주세요.
- 시험 제출 버튼 하단 배치가 모바일에서도 자연스러운지 확인해 주세요.

---

## 📸 결과 (선택)
- `npm run build` 성공

---

## 🔗 관련 이슈
Closes #13

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료
