### PR TITLE
[Feature] 학습모드 카드형 전환

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -63,6 +63,170 @@ main {
   margin-bottom: 20px;
 }
 
+.study-toolbar {
+  gap: 20px;
+}
+
+.study-toolbar-head {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 20px;
+  align-items: start;
+}
+
+.study-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: flex-end;
+}
+
+.study-filter-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.study-meta-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+}
+
+.study-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.study-progress-track {
+  height: 12px;
+  border-radius: 999px;
+  overflow: hidden;
+  background: rgba(217, 186, 145, 0.28);
+}
+
+.study-progress-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--accent), #b57f4d);
+  transition: width 180ms ease;
+}
+
+.toc-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+  gap: 12px;
+}
+
+.toc-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+  min-height: 112px;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: rgba(255, 255, 255, 0.74);
+  color: var(--text);
+  text-align: left;
+  transition:
+    transform 160ms ease,
+    border-color 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.toc-item:hover {
+  transform: translateY(-1px);
+  border-color: var(--accent-soft);
+  box-shadow: 0 12px 24px rgba(89, 58, 24, 0.08);
+}
+
+.toc-item.active {
+  border-color: var(--accent);
+  background: rgba(217, 186, 145, 0.22);
+}
+
+.toc-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  height: 32px;
+  padding: 0 10px;
+  border-radius: 999px;
+  background: var(--surface-strong);
+  color: var(--text);
+  font-weight: 700;
+}
+
+.toc-item p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.deck-frame {
+  animation-duration: 220ms;
+  animation-fill-mode: both;
+}
+
+.deck-frame--forward {
+  animation-name: slide-forward;
+}
+
+.deck-frame--backward {
+  animation-name: slide-backward;
+}
+
+.study-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.hint-box {
+  padding: 16px;
+  border-radius: 18px;
+  background: rgba(138, 90, 50, 0.07);
+  border: 1px solid rgba(138, 90, 50, 0.15);
+}
+
+.hint-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.hint-list p {
+  margin: 4px 0 0;
+}
+
+@keyframes slide-forward {
+  from {
+    opacity: 0;
+    transform: translateX(18px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+@keyframes slide-backward {
+  from {
+    opacity: 0;
+    transform: translateX(-18px) scale(0.99);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
 .actions {
   display: flex;
   gap: 12px;
@@ -193,6 +357,16 @@ ul {
 @media (max-width: 720px) {
   .grid.columns-2 {
     grid-template-columns: 1fr;
+  }
+
+  .study-toolbar-head,
+  .study-filter-grid,
+  .hint-list {
+    grid-template-columns: 1fr;
+  }
+
+  .study-badges {
+    justify-content: flex-start;
   }
 
   .page {

--- a/frontend/src/app/study/page.tsx
+++ b/frontend/src/app/study/page.tsx
@@ -1,23 +1,25 @@
 import { BackLink } from "@/components/BackLink";
 import { StudyDeck } from "@/components/StudyDeck";
-import { getQuestions } from "@/lib/api";
+import { getQuestions, getUnits } from "@/lib/api";
 
 export default async function StudyPage() {
-  const questions = await getQuestions();
+  const [units, questions] = await Promise.all([getUnits(), getQuestions()]);
 
   return (
     <main>
       <div className="page">
         <section className="hero stack">
           <div className="badge">학습 모드</div>
-          <h1>문제를 보고 먼저 떠올린 뒤, 바로 정답을 확인합니다.</h1>
-          <p className="muted">정답을 가렸다가 펼치고, 외운 문제는 숨기면서 반복 회상할 수 있습니다.</p>
+          <h1>단원과 파트를 고르고, 카드 한 장씩 넘기며 회상합니다.</h1>
+          <p className="muted">
+            목차를 보고 범위를 좁힌 뒤, 힌트와 정답을 단계적으로 펼치면서 셀프 체크할 수 있습니다.
+          </p>
           <div className="actions">
             <BackLink fallbackHref="/" />
           </div>
         </section>
 
-        <StudyDeck questions={questions} />
+        <StudyDeck questions={questions} units={units} />
       </div>
     </main>
   );

--- a/frontend/src/components/StudyDeck.tsx
+++ b/frontend/src/components/StudyDeck.tsx
@@ -1,111 +1,296 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { QuestionCard } from "@/components/QuestionCard";
-import type { QuestionDetail } from "@/lib/types";
+import type { QuestionDetail, UnitSummary } from "@/lib/types";
 
 type Props = {
   questions: QuestionDetail[];
+  units: UnitSummary[];
 };
 
-export function StudyDeck({ questions }: Props) {
-  const [revealedIds, setRevealedIds] = useState<Record<string, boolean>>({});
-  const [rememberedIds, setRememberedIds] = useState<Record<string, boolean>>({});
-  const [hideRemembered, setHideRemembered] = useState(true);
+type Direction = "forward" | "backward";
 
-  const rememberedCount = questions.filter((question) => rememberedIds[question.questionId]).length;
-  const remainingCount = questions.length - rememberedCount;
-  const visibleQuestions = hideRemembered
-    ? questions.filter((question) => !rememberedIds[question.questionId])
-    : questions;
-
-  function toggleAnswer(questionId: string) {
-    setRevealedIds((current) => ({
-      ...current,
-      [questionId]: !current[questionId]
-    }));
+function shorten(text: string, maxLength = 56) {
+  if (text.length <= maxLength) {
+    return text;
   }
 
-  function toggleRemembered(questionId: string) {
+  return `${text.slice(0, maxLength - 1).trimEnd()}…`;
+}
+
+function getQuestionLabel(question: QuestionDetail) {
+  return question.title?.trim() || question.prompts[0] || question.questionId;
+}
+
+export function StudyDeck({ questions, units }: Props) {
+  const [selectedUnitId, setSelectedUnitId] = useState("all");
+  const [selectedPart, setSelectedPart] = useState("all");
+  const [hideRemembered, setHideRemembered] = useState(true);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [rememberedIds, setRememberedIds] = useState<Record<string, boolean>>({});
+  const [revealAnswer, setRevealAnswer] = useState(false);
+  const [showHint, setShowHint] = useState(false);
+  const [direction, setDirection] = useState<Direction>("forward");
+
+  const selectedUnit = selectedUnitId === "all" ? null : units.find((unit) => unit.unitId === selectedUnitId) ?? null;
+
+  const partOptions =
+    selectedUnitId === "all"
+      ? Array.from(new Set(units.flatMap((unit) => unit.parts)))
+      : selectedUnit?.parts ?? [];
+
+  const catalogQuestions = questions.filter((question) => {
+    if (selectedUnitId !== "all" && question.unitId !== selectedUnitId) {
+      return false;
+    }
+
+    if (selectedPart !== "all" && question.part !== selectedPart) {
+      return false;
+    }
+
+    return true;
+  });
+
+  const visibleQuestions = hideRemembered
+    ? catalogQuestions.filter((question) => !rememberedIds[question.questionId])
+    : catalogQuestions;
+
+  const visibleCount = visibleQuestions.length;
+  const activeIndex = visibleCount === 0 ? 0 : Math.min(currentIndex, visibleCount - 1);
+  const currentQuestion = visibleCount > 0 ? visibleQuestions[activeIndex] : null;
+  const rememberedCount = catalogQuestions.filter((question) => rememberedIds[question.questionId]).length;
+  const progressValue = visibleCount === 0 ? 0 : ((activeIndex + 1) / visibleCount) * 100;
+
+  useEffect(() => {
+    setCurrentIndex(0);
+    setRevealAnswer(false);
+    setShowHint(false);
+  }, [hideRemembered, selectedPart, selectedUnitId]);
+
+  useEffect(() => {
+    if (selectedPart !== "all" && !partOptions.includes(selectedPart)) {
+      setSelectedPart("all");
+    }
+  }, [selectedUnitId]);
+
+  function goToIndex(nextIndex: number, nextDirection: Direction) {
+    if (visibleCount === 0) {
+      return;
+    }
+
+    const clampedIndex = Math.max(0, Math.min(nextIndex, visibleCount - 1));
+    setDirection(nextDirection);
+    setCurrentIndex(clampedIndex);
+    setRevealAnswer(false);
+    setShowHint(false);
+  }
+
+  function handleRemembered(questionId: string, nextRemembered: boolean) {
     setRememberedIds((current) => ({
       ...current,
-      [questionId]: !current[questionId]
+      [questionId]: nextRemembered
     }));
+    setRevealAnswer(false);
+    setShowHint(false);
+
+    if (!hideRemembered) {
+      goToIndex(activeIndex + 1, "forward");
+    }
   }
 
   function resetSession() {
-    setRevealedIds({});
-    setRememberedIds({});
+    setSelectedUnitId("all");
+    setSelectedPart("all");
     setHideRemembered(true);
+    setCurrentIndex(0);
+    setRememberedIds({});
+    setRevealAnswer(false);
+    setShowHint(false);
+    setDirection("forward");
   }
 
   return (
     <div className="stack">
-      <section className="panel stack">
-        <div className="actions">
-          <div className="badge">전체 {questions.length}</div>
-          <div className="badge secondary-badge">외운 문제 {rememberedCount}</div>
-          <div className="badge secondary-badge">다시 볼 문제 {remainingCount}</div>
+      <section className="panel stack study-toolbar">
+        <div className="study-toolbar-head">
+          <div className="stack">
+            <div className="badge">목차</div>
+            <h2>단원과 파트를 고르고, 카드 한 장씩 넘기세요.</h2>
+            <p className="muted">
+              정답을 바로 펼치지 않고, 먼저 떠올린 뒤 힌트와 정답을 확인하는 셀프 체크 흐름입니다.
+            </p>
+          </div>
+
+          <div className="study-badges">
+            <div className="badge">전체 {catalogQuestions.length}</div>
+            <div className="badge secondary-badge">학습 중 {visibleCount}</div>
+            <div className="badge secondary-badge">외운 문제 {rememberedCount}</div>
+          </div>
         </div>
-        <label className="checkbox-row">
-          <input
-            checked={hideRemembered}
-            type="checkbox"
-            onChange={(event) => setHideRemembered(event.target.checked)}
-          />
-          <span>외운 문제는 목록에서 숨기기</span>
-        </label>
-        <div className="actions">
-          <button className="secondary" type="button" onClick={resetSession}>
-            다시 시작하기
-          </button>
+
+        <div className="study-filter-grid">
+          <label className="stack">
+            <span>단원</span>
+            <select value={selectedUnitId} onChange={(event) => setSelectedUnitId(event.target.value)}>
+              <option value="all">전체 단원</option>
+              {units.map((unit) => (
+                <option key={unit.unitId} value={unit.unitId}>
+                  {unit.unitId} · {unit.title}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="stack">
+            <span>파트</span>
+            <select value={selectedPart} onChange={(event) => setSelectedPart(event.target.value)}>
+              <option value="all">전체 파트</option>
+              {partOptions.map((part) => (
+                <option key={part} value={part}>
+                  {part}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <div className="study-meta-row">
+          <label className="checkbox-row">
+            <input
+              checked={hideRemembered}
+              type="checkbox"
+              onChange={(event) => setHideRemembered(event.target.checked)}
+            />
+            <span>외운 문제는 카드에서 숨기기</span>
+          </label>
+
+          <div className="actions">
+            <button className="secondary" type="button" onClick={resetSession}>
+              초기화
+            </button>
+          </div>
+        </div>
+
+        <div className="study-progress">
+          <div className="study-progress-track" aria-hidden="true">
+            <span style={{ width: `${progressValue}%` }} />
+          </div>
+          <p className="muted">
+            {selectedUnit ? `${selectedUnit.unitId} · ${selectedUnit.title}` : "전체 단원"} /{" "}
+            {selectedPart === "all" ? "전체 파트" : selectedPart}
+          </p>
+        </div>
+
+        <div className="toc-grid" role="list" aria-label="학습 목차">
+          {visibleQuestions.length === 0 ? (
+            <p className="muted">선택한 범위에 아직 남은 카드가 없습니다. 필터를 바꾸거나 초기화해 보세요.</p>
+          ) : (
+            visibleQuestions.map((question, index) => {
+              const isActive = index === activeIndex;
+
+              return (
+                <button
+                  key={question.questionId}
+                  className={`toc-item ${isActive ? "active" : ""}`}
+                  type="button"
+                  onClick={() => goToIndex(index, index > activeIndex ? "forward" : "backward")}
+                >
+                  <span className="toc-index">{index + 1}</span>
+                  <strong>{question.part}</strong>
+                  <p>{shorten(getQuestionLabel(question))}</p>
+                </button>
+              );
+            })
+          )}
         </div>
       </section>
 
-      {visibleQuestions.length === 0 ? (
-        <section className="panel stack">
-          <h2>모든 문제를 외웠습니다.</h2>
-          <p className="muted">외운 문제 숨기기를 끄면 다시 전체 목록을 볼 수 있습니다.</p>
-        </section>
-      ) : null}
-
-      {visibleQuestions.map((question, index) => {
-        const isRevealed = revealedIds[question.questionId] ?? false;
-        const isRemembered = rememberedIds[question.questionId] ?? false;
-
-        return (
+      {currentQuestion ? (
+        <div className={`deck-frame deck-frame--${direction}`} key={currentQuestion.questionId}>
           <QuestionCard
-            key={question.questionId}
-            index={index}
-            prompts={question.prompts}
-            meta={`${question.unitId} / ${question.part} / ${question.type}`}
+            index={activeIndex}
+            meta={`${currentQuestion.unitId} / ${currentQuestion.part} / ${currentQuestion.type}`}
+            prompts={currentQuestion.prompts}
           >
             <div className="stack">
-              {isRevealed ? (
-                <div className="study-answer">
-                  <strong>정답</strong>
-                  <p>{question.answers.join(" / ")}</p>
+              <p className="muted">먼저 답을 떠올리고, 힌트와 정답은 필요할 때만 펼쳐 보세요.</p>
+
+              <div className="study-action-row">
+                <button className="secondary" type="button" onClick={() => setShowHint((current) => !current)}>
+                  {showHint ? "힌트 닫기" : "힌트 보기"}
+                </button>
+                <button className="secondary" type="button" onClick={() => setRevealAnswer((current) => !current)}>
+                  {revealAnswer ? "정답 숨기기" : "정답 보기"}
+                </button>
+              </div>
+
+              {showHint ? (
+                <div className="hint-box stack">
+                  <strong>힌트</strong>
+                  <div className="hint-list">
+                    <div>
+                      <span className="muted">키워드</span>
+                      <p>{currentQuestion.keywords.length ? currentQuestion.keywords.join(" / ") : "등록된 키워드 없음"}</p>
+                    </div>
+                    <div>
+                      <span className="muted">연관 표현</span>
+                      <p>{currentQuestion.aliases.length ? currentQuestion.aliases.join(" / ") : "등록된 대체 표현 없음"}</p>
+                    </div>
+                  </div>
                 </div>
-              ) : (
-                <p className="muted">답을 먼저 떠올려 보고, 필요할 때만 정답을 확인하세요.</p>
-              )}
-              <div className="actions">
-                <button className="secondary" type="button" onClick={() => toggleAnswer(question.questionId)}>
-                  {isRevealed ? "정답 숨기기" : "정답 보기"}
+              ) : null}
+
+              {revealAnswer ? (
+                <div className="study-answer stack">
+                  <strong>정답</strong>
+                  <p>{currentQuestion.answers.join(" / ")}</p>
+                </div>
+              ) : null}
+
+              <div className="study-action-row">
+                <button type="button" onClick={() => handleRemembered(currentQuestion.questionId, true)}>
+                  외웠어요
                 </button>
                 <button
+                  className="secondary"
                   type="button"
-                  className={isRemembered ? "secondary" : undefined}
-                  onClick={() => toggleRemembered(question.questionId)}
+                  onClick={() => handleRemembered(currentQuestion.questionId, false)}
                 >
-                  {isRemembered ? "다시 볼래요" : "외웠어요"}
+                  다시 볼래요
+                </button>
+                <button
+                  className="secondary"
+                  disabled={activeIndex === 0}
+                  type="button"
+                  onClick={() => goToIndex(activeIndex - 1, "backward")}
+                >
+                  이전 카드
+                </button>
+                <button
+                  className="secondary"
+                  disabled={activeIndex >= visibleCount - 1}
+                  type="button"
+                  onClick={() => goToIndex(activeIndex + 1, "forward")}
+                >
+                  다음 카드
                 </button>
               </div>
             </div>
           </QuestionCard>
-        );
-      })}
+        </div>
+      ) : (
+        <section className="panel stack">
+          <h2>학습할 카드가 없습니다.</h2>
+          <p className="muted">선택한 단원과 파트에서 모든 카드를 외웠거나, 필터가 너무 좁을 수 있습니다.</p>
+          <div className="actions">
+            <button type="button" onClick={resetSession}>
+              필터 초기화
+            </button>
+          </div>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] 학습모드 카드형 전환

---

## 📌 작업 내용 (What)
- 학습모드에 Unit / Part 선택 UI를 추가함
- 리스트형 학습모드를 카드형 학습 흐름으로 전환함
- 상단 목차와 진행 정보를 추가함
- 카드 전환 애니메이션과 AI 없는 셀프 체크/힌트 구조를 추가함

---

## 🎯 작업 이유 (Why)
- 학습 범위를 더 세밀하게 조절하고 싶음
- 한 번에 하나씩 넘기는 방식으로 회상 학습 흐름을 자연스럽게 만들기 위함
- 정답을 바로 보지 않고 스스로 떠올리는 구조가 필요함

---

## 🔧 변경 사항 (How)
- `/study` 화면에서 `getUnits()`와 `getQuestions()`를 함께 불러와 단원/파트 선택을 지원함
- `StudyDeck`를 카드형 진행 컴포넌트로 재구성하고 목차, 진행바, 셀프 체크 버튼, 힌트/정답 토글을 추가함
- 전환 방향에 따라 슬라이드 애니메이션을 적용하고 모바일 레이아웃도 함께 맞춤

---

## 📁 변경 파일
- frontend/src/app/study/page.tsx
- frontend/src/components/StudyDeck.tsx
- frontend/src/app/globals.css

---

## 🧪 테스트 방법
1. `cd /Users/inchoi/prepareExam/frontend`
2. `npm run build`
3. `/study` 화면에서 Unit / Part를 바꿔 본다.
4. 카드 한 장씩 넘기며 정답 보기, 힌트 보기, 외웠어요 / 다시 볼래요를 확인한다.

---

## ⚠️ 영향 범위
- 학습모드 UI와 학습 흐름에만 영향이 있음
- 시험/채점 API와 오답노트 기능에는 직접 영향이 없음

---

## 🔥 리뷰 포인트
- Unit / Part 선택 시 카드 필터링이 의도대로 동작하는지
- 카드 전환과 초기화 흐름이 자연스러운지
- 기존 시험 관련 화면 스타일과 충돌하지 않는지

---

## 📸 결과 (선택)
- `npm run build` 통과

---

## 🔗 관련 이슈
Closes #20

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료
