### PR TITLE
[Feature] 기본 이슈 assignee를 InryeolChoi로 설정

### DIFF
--- a/.github/ISSUE_TEMPLATE/dev.md
+++ b/.github/ISSUE_TEMPLATE/dev.md
@@ -5,7 +5,7 @@ name: 🛠 Feature / Fix
 about: 기능 개발 및 버그 수정
 title: "[Feature] "
 labels: backend
-assignees: ''
+assignees: [InryeolChoi]
 ---
 
 ## 📌 작업 내용
@@ -34,3 +34,4 @@ assignees: ''
 ## ⚠️ 참고사항
 - PR 필수
 - Closes #이슈번호 반드시 포함
+- 새 이슈는 기본적으로 `InryeolChoi`에 할당됩니다.

--- a/.github/ISSUE_TEMPLATE/theory.md
+++ b/.github/ISSUE_TEMPLATE/theory.md
@@ -5,7 +5,7 @@ name: 📚 Theory 작성
 about: 정처기 이론 작성 및 수정
 title: "[Theory] "
 labels: theory
-assignees: ''
+assignees: [InryeolChoi]
 ---
 
 ## 📌 대상 unit
@@ -34,3 +34,4 @@ assignees: ''
 ## ⚠️ 참고사항
 - 기존 내용 삭제 금지
 - diff 기반 수정
+- 새 이슈는 기본적으로 `InryeolChoi`에 할당됩니다.


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] 기본 이슈 assignee를 InryeolChoi로 설정

---

## 📌 작업 내용 (What)
- `.github/ISSUE_TEMPLATE/dev.md`와 `.github/ISSUE_TEMPLATE/theory.md`의 기본 assignee를 `InryeolChoi`로 지정했습니다.
- 새 이슈 생성 시 담당자 누락을 줄이도록 안내 문구를 추가했습니다.

---

## 🎯 작업 이유 (Why)
- Issue 생성 단계에서 담당자를 자동으로 맞춰 협업 흐름을 단순화하기 위함입니다.
- 템플릿 수준에서 운영 기준을 보조해 수동 실수를 줄이기 위함입니다.

---

## 🔧 변경 사항 (How)
- issue template front matter의 `assignees`를 배열 형태로 설정했습니다.
- 참고사항에 기본 assignee 안내 문구를 추가했습니다.

---

## 📁 변경 파일
- `.github/ISSUE_TEMPLATE/dev.md`
- `.github/ISSUE_TEMPLATE/theory.md`

---

## 🧪 테스트 방법
1. GitHub에서 `Feature / Fix` 템플릿으로 새 이슈를 생성한다.
2. `InryeolChoi`가 기본 assignee로 지정되는지 확인한다.
3. `Theory 작성` 템플릿에서도 동일하게 동작하는지 확인한다.

---

## ⚠️ 영향 범위
- `.github` issue templates에만 영향이 있습니다.
- 애플리케이션 코드나 실행 로직에는 영향이 없습니다.

---

## 🔥 리뷰 포인트
- GitHub issue template에서 `assignees` 배열 지정이 의도대로 동작하는지 확인해 주세요.
- 안내 문구가 운영 기준을 충분히 보완하는지 봐주세요.

---

## 📸 결과 (선택)
- 없음

---

## 🔗 관련 이슈
Closes #26

---

## ✅ 체크리스트
- [ ] 코드 실행 확인
- [ ] 기본 기능 테스트 완료
- [ ] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료