### PR TITLE
[Feature] README를 외부 노트 연동 아키텍처 기준으로 개편

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
 
-### External notes become a searchable question bank
+### Markdown notes become a living question bank
 
 [![Next.js](https://img.shields.io/badge/Next.js-16-111111?style=for-the-badge&logo=next.js)](https://nextjs.org/)
 [![React](https://img.shields.io/badge/React-19-20232A?style=for-the-badge&logo=react)](https://react.dev/)
@@ -10,126 +10,85 @@
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.8-3178C6?style=for-the-badge&logo=typescript)](https://www.typescriptlang.org/)
 [![Python](https://img.shields.io/badge/Python-3.x-3776AB?style=for-the-badge&logo=python)](https://www.python.org/)
 
-이 프로젝트는 별도 저장소 `active-recall-notes`에 있는 Markdown 노트를  
-CI/CD로 수집해 이 앱의 SQLite에 적재하고,  
-그 데이터를 바탕으로 문제 생성, 시험, 채점, 오답 복습 흐름을 제공합니다.
+이 저장소는 학습 노트를 직접 보관하는 곳이 아니라,  
+`active-recall-notes` 저장소에서 가져온 데이터를 SQLite에 적재하고  
+문제 생성, 시험 응시, 채점, 오답 복습 흐름을 제공하는 앱입니다.
 
 </div>
 
 ---
 
-## Why This Project
+## Overview
 
-학습 노트와 문제 풀이가 같은 저장소에 묶여 있으면 다음 문제가 생깁니다.
+이 프로젝트의 핵심은 "노트 저장소"와 "학습 앱"의 책임 분리입니다.
 
-- 노트와 애플리케이션의 책임이 섞입니다.
-- 콘텐츠 갱신과 앱 배포 주기가 충돌합니다.
-- 로컬 Markdown 폴더에 의존하면 데이터 관리가 분산됩니다.
+- 노트 원본은 `active-recall-notes` 저장소에서 관리합니다.
+- 이 저장소는 CI/CD로 동기화된 노트 데이터를 받아 SQLite에 저장합니다.
+- 프론트엔드는 저장된 문제와 결과를 바탕으로 학습/시험 UX를 제공합니다.
 
-이 저장소는 그 흐름을 분리합니다.
+즉, Markdown을 직접 읽는 앱이 아니라,  
+외부 노트 레포를 데이터 공급원으로 삼는 학습 시스템입니다.
 
-> `active-recall-notes -> CI/CD sync -> SQLite -> question bank -> exam session -> grading -> wrong notes`
-
-즉, 콘텐츠는 별도 레포에서 관리하고, 이 앱은 그 데이터를 읽어 학습 경험을 제공하는 역할에 집중합니다.
-
-## Architecture
+## Data Flow
 
 ```mermaid
 flowchart LR
-    A["active-recall-notes"] --> B["CI/CD Sync"]
-    B --> C["SQLite"]
-    C --> D["Normalizer / Parser"]
-    D --> E["Question Bank"]
-    E --> F["Study Mode"]
-    E --> G["Exam Generator"]
-    G --> H["Exam Submission"]
-    H --> I["Grading Result"]
-    I --> J["Wrong Notes"]
+    A["active-recall-notes"] --> B["CI/CD sync"]
+    B --> C["SQLite in this repo"]
+    C --> D["Backend API"]
+    D --> E["Study UI"]
+    D --> F["Exam UI"]
+    F --> G["Grading Result"]
+    G --> H["Wrong Notes"]
 ```
 
-## Highlights
+## What This Repo Owns
 
-- Markdown 노트는 이 저장소가 아니라 `active-recall-notes`에서 관리합니다.
-- CI/CD 파이프라인이 외부 노트를 수집해 SQLite에 적재하는 흐름을 전제로 합니다.
-- FastAPI가 시험 생성, 제출, 채점 API를 제공합니다.
-- Next.js App Router 기반 화면에서 학습, 시험, 결과, 오답노트를 확인합니다.
-- 오답 결과는 프론트엔드 로컬 스토리지에 저장해 재복습할 수 있습니다.
+- 노트 데이터의 수집 결과 저장
+- 시험 세션 및 채점 API
+- 학습/시험/결과 화면
+- 오답 복습 경험
 
-## Repository Scope
+## What This Repo Does Not Own
 
-이 저장소의 책임은 콘텐츠 작성이 아니라, 이미 수집된 노트를 학습 가능한 서비스로 바꾸는 것입니다.
+- 노트 원본 작성
+- 노트 콘텐츠의 장기 저장소 역할
+- `unit_*` 기반 로컬 문서 저장소 역할
 
-- `backend`: 데이터 적재, 질문 생성, 시험, 채점, 통계 API
-- `frontend`: 학습/시험/결과/오답노트 UI
-- `shared`: 공용 계약이나 산출물
-- `active-recall-notes`: 원본 Markdown 노트 저장소
-
-## Project Structure
+## Repository Structure
 
 ```text
 .
-├── backend                 # FastAPI API, SQLite access, grading logic
+├── backend
 │   ├── app
-│   │   ├── api             # REST endpoints
-│   │   ├── parsers         # markdown normalization / ingestion helpers
-│   │   ├── schemas         # pydantic models
-│   │   ├── services        # question / exam / grading / stats
-│   │   └── utils           # ids, text normalization
-│   └── tests               # parser / grading tests
-├── frontend                # Next.js UI
+│   │   ├── api
+│   │   ├── parsers
+│   │   ├── schemas
+│   │   ├── services
+│   │   └── utils
+│   └── tests
+├── frontend
 │   └── src
-│       ├── app             # routes
-│       ├── components      # UI components
-│       └── lib             # API client, types, wrong-note storage
-└── shared/openapi.json     # shared contract placeholder
+│       ├── app
+│       ├── components
+│       └── lib
+├── shared
+└── README.md
 ```
-
-## Data Model
-
-- Source of truth: `active-recall-notes`
-- Synchronized storage: SQLite in this repository
-- Runtime API: FastAPI reads from SQLite and serves normalized question data
-- Client-side cache: browser `localStorage` for wrong notes
 
 ## Key Screens
 
-### 1. Home
-- 수집된 단원과 파싱된 문제 수를 요약해서 보여줍니다.
-- 학습 모드, 시험 모드, 오답노트로 바로 이동할 수 있습니다.
+### 1. Study Mode
+- 문제를 먼저 보고 답을 떠올린 뒤 정답을 확인합니다.
+- 빠른 회상 연습을 위한 진입점입니다.
 
-### 2. Study Mode
-- 문제를 먼저 보고 답을 떠올린 뒤 정답을 확인하는 흐름입니다.
-- 현재는 빠른 검증용 초기 버전이라 정답이 함께 노출됩니다.
+### 2. Exam Mode
+- 단원과 파트를 기준으로 시험 세트를 생성합니다.
+- 생성된 문제를 서술형으로 입력하고 제출합니다.
 
-### 3. Exam Mode
-- 단원과 파트를 고른 뒤 시험 세트를 생성합니다.
-- 생성된 문제를 서술형으로 입력하고 한 번에 제출합니다.
-
-### 4. Result + Wrong Notes
-- 정답 여부, 점수, 누락 키워드 중심으로 결과를 확인합니다.
-- 틀린 문제는 오답노트로 저장해 다시 볼 수 있습니다.
-
-## Markdown Question Format
-
-`active-recall-notes`에 들어 있는 Markdown은 가능한 한 단순한 규칙으로 정규화됩니다.
-
-- `*`로 시작하는 줄: 문제 설명
-- `->`로 시작하는 줄: 정답
-- `*` 또는 `->` 다음 일반 텍스트 줄: 직전 항목에 이어 붙임
-- 하나의 블록에 `->`가 여러 개 있으면: 나열형 문제로 취급
-- 형식이 조금 어긋난 줄도: 경고를 남기고 최대한 계속 파싱
-
-예시:
-
-```md
-* 소프트웨어 생명 주기를 설명하시오.
--> 소프트웨어 생명 주기
-
-* 자료 흐름도의 특징을 쓰시오.
--> 자료의 흐름
--> 처리 과정
--> 데이터 저장소
-```
+### 3. Result + Wrong Notes
+- 정답 여부, 점수, 누락 키워드를 확인합니다.
+- 틀린 문제는 오답노트로 이어집니다.
 
 ## Tech Stack
 
@@ -137,13 +96,13 @@ flowchart LR
 | --- | --- |
 | Frontend | Next.js 16, React 19, TypeScript |
 | Backend | FastAPI, Pydantic, Uvicorn |
-| Data Source | `active-recall-notes` repository |
-| Persistence | SQLite, browser `localStorage` |
+| Data Source | `active-recall-notes` via CI/CD sync |
+| Persistence | SQLite |
 | Testing | pytest |
 
-## Run Locally
+## Local Run
 
-### 1. Backend
+### Backend
 
 ```bash
 cd /Users/inchoi/active_recall_quiz/backend
@@ -153,12 +112,12 @@ pip install -r requirements.txt
 uvicorn app.main:app --reload
 ```
 
-기본 서버:
+Backend defaults:
 
 - `http://127.0.0.1:8000`
 - health check: `GET /health`
 
-### 2. Frontend
+### Frontend
 
 ```bash
 cd /Users/inchoi/active_recall_quiz/frontend
@@ -166,16 +125,12 @@ npm install
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000/api npm run dev
 ```
 
-프론트 주요 화면:
+Frontend routes:
 
-- `/study`: 학습 모드
-- `/exam`: 시험 옵션 선택 후 시험 생성
-- `/results/[examId]`: 채점 결과
-- `/wrong-notes`: 오답노트
-
-기본 프론트엔드:
-
-- `http://127.0.0.1:3000`
+- `/study`
+- `/exam`
+- `/results/[examId]`
+- `/wrong-notes`
 
 ## API Snapshot
 
@@ -193,38 +148,14 @@ NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000/api npm run dev
 - `POST /api/exams`
 - `POST /api/exams/{examId}/submit`
 
-## Test
+## Current Direction
 
-```bash
-cd /Users/inchoi/active_recall_quiz/backend
-pytest
-```
+- 노트 원본은 외부 레포에서 관리합니다.
+- 앱은 동기화된 노트 데이터를 바탕으로 학습 경험을 제공합니다.
+- 내부 저장은 SQLite를 기준으로 맞춰갑니다.
+- 로컬 Markdown 파일 의존은 점차 줄여갑니다.
 
-현재 테스트는 아래 핵심 흐름을 확인합니다.
+## Notes
 
-- 노트 정규화와 문제 변환
-- 단답형 채점 로직
-
-## Current Architecture Notes
-
-- 현재 목표는 로컬 Markdown 폴더가 아니라 외부 노트 저장소를 기준으로 동작하는 것입니다.
-- 데이터는 `active-recall-notes`에서 동기화되고, 이 저장소의 SQLite에 저장되는 흐름을 전제로 합니다.
-- 앱은 콘텐츠 저장소를 직접 편집하지 않고, 수집된 데이터를 서비스 계층에서 활용합니다.
-- 오답노트는 브라우저 `localStorage`에 저장됩니다.
-
-## Roadmap Ideas
-
-- CI/CD 기반 동기화 파이프라인 안정화
-- 문제 난이도/태그/단원별 가중치 출제
-- 결과 영속화 및 사용자별 기록 저장
-- OpenAPI 문서 자동 생성 및 `shared/openapi.json` 정리
-- 오답노트 재시험 모드
-- LLM 기반 유사 답안 채점 보조
-
-## Repository Intent
-
-이 저장소는 단순한 퀴즈 앱보다,  
-외부 Markdown 노트를 학습 가능한 서비스 데이터로 바꾸는 시스템입니다.
-
-콘텐츠는 `active-recall-notes`에서 관리하고,  
-이 저장소는 SQLite, API, UI를 통해 회상 학습 경험을 제공합니다.
+- 이 저장소는 학습 도구의 실행 계층에 집중합니다.
+- 콘텐츠 운영과 이론 작성은 `active-recall-notes` 쪽에서 진행합니다.


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] README를 외부 노트 연동 아키텍처 기준으로 개편

---

## 📌 작업 내용 (What)
- `README.md`를 외부 노트 레포 `active-recall-notes` 연동 구조 기준으로 개편함
- 로컬 `unit_*` 중심 설명을 제거하고, 외부 레포 -> CI/CD -> SQLite 흐름을 반영함
- 현재 구현 상태와 목표 아키텍처가 섞이지 않도록 문서 표현을 조정함

---

## 🎯 작업 이유 (Why)
- 저장소 책임을 콘텐츠 저장소와 애플리케이션 저장소로 분리해서 설명하기 위함
- 신규 기여자가 현재 아키텍처 전환 방향을 한눈에 이해할 수 있게 하기 위함

---

## 🔧 변경 사항 (How)
- 아키텍처 다이어그램과 데이터 흐름을 외부 레포 기반으로 재작성함
- Tech Stack과 Current Architecture Notes를 SQLite 기준으로 정리함
- 로컬 Markdown 소스 전제 문구를 축소하고, repository scope를 재정의함

---

## 📁 변경 파일
- /Users/inchoi/active_recall_quiz/README.md

---

## 🧪 테스트 방법
1. README.md를 열어 외부 노트 레포와 SQLite 흐름이 명확하게 드러나는지 확인한다.
2. 로컬 `unit_*` 폴더가 프로젝트의 핵심 소스로 읽히지 않는지 확인한다.
3. 현재 상태와 목표 상태가 혼동되지 않게 서술되었는지 확인한다.

---

## ⚠️ 영향 범위
- 문서 변경만 있으므로 런타임 동작에는 영향이 없다.
- 다른 파일은 수정하지 않았다.

---

## 🔥 리뷰 포인트
- README가 외부 노트 레포 중심의 아키텍처를 과장 없이 전달하는지
- 현재 구현과 목표 아키텍처가 혼동되지 않는지

---

## 📸 결과 (선택)
- 문서 작업이라 별도 스크린샷 없음

---

## 🔗 관련 이슈
Closes #28

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료