### PR TITLE
[Feature] 프론트 영향 검토

### DIFF
--- a/frontend/docs/source-transition-review.md
+++ b/frontend/docs/source-transition-review.md
@@ -1,0 +1,70 @@
+# Frontend Source Transition Review
+
+## Scope
+
+This review covers how the frontend reacts when the data source moves from local `unit_*` markdown files to an external `active-recall-notes` repository plus SQLite-backed storage.
+
+The goal is to separate changes that must happen immediately from changes that can wait until the backend contract is finalized.
+
+## Current Frontend Contract
+
+The UI currently depends on a stable unit/question contract:
+
+- Home and exam pages load units for summaries and selection.
+- Study mode filters questions by `unitId` and `part`.
+- Exam setup sends `unitIds`, `parts`, `questionCount`, `mode`, and `shuffle`.
+- Exam detail and result screens assume exam and grading payloads remain shaped around stable question ids.
+
+The most visible contract fields are:
+
+- `UnitSummary`: `unitId`, `title`, `parts`, `questionCount`
+- `QuestionDetail`: `questionId`, `unitId`, `part`, `title`, `prompts`, `answers`, `aliases`, `keywords`, `warnings`
+- `ExamDetail`: `examId`, `mode`, `createdAt`, `unitIds`, `parts`, `questionCount`, `questions`
+- `GradingResult`: `examId`, `score`, `total`, `submittedAt`, `results`
+
+## Immediate Impact
+
+These items need attention as soon as the backend contract changes:
+
+- If `unitId` is renamed or removed, unit pickers and study filters will break.
+- If `parts` changes shape, both study filtering and exam setup will need updates.
+- If question titles/prompts/aliases/keywords are dropped, study cards and exam labels will need new fallback text.
+- If `createExam` stops accepting `unitIds` and `parts`, the exam setup form must be rewritten.
+- If `getUnits` becomes paginated or source-specific, the home and exam pages must stop assuming a complete in-memory list.
+
+## Safe To Defer
+
+These changes can wait until the backend schema and sync pipeline are stable:
+
+- Adding extra source metadata from SQLite.
+- Showing repository provenance, source file paths, or source line numbers in the UI.
+- Changing copy that mentions "markdown" as long as the visible workflow still works.
+- Adapting to new storage internals if the API shape stays compatible.
+
+## Contract Dependencies
+
+### Backend Analysis `#30`
+
+The frontend should not need to know how `unit_*` paths are removed, as long as the backend keeps returning the same logical unit/question identifiers. The important boundary is the response shape, not the storage mechanism.
+
+### SQLite Schema `#31`
+
+Schema changes are safe for the frontend only if record identifiers and question grouping stay stable. If the schema introduces new ids or new grouping rules, the frontend selection flow needs to be updated together with the API contract.
+
+### Sync Flow `#32`
+
+The sync pipeline should produce stable ids, stable unit titles, and stable part grouping. If sync introduces partial updates or delayed availability, the UI may need loading and empty-state copy adjustments.
+
+## Recommended Order
+
+1. Keep the current `UnitSummary` and `QuestionDetail` shape stable until the backend migration is ready.
+2. Let the backend absorb source normalization and SQLite mapping first.
+3. Update the frontend only when a contract change is unavoidable.
+4. Remove `markdown` wording from the UI copy only after the new source flow is confirmed.
+
+## Checklist
+
+- [x] Identify the frontend pages that depend on unit/question contracts
+- [x] Separate immediate breakpoints from deferred changes
+- [x] Connect the review to `#30`, `#31`, and `#32`
+- [x] Keep the work limited to documentation


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] 프론트 영향 검토

---

## 📌 작업 내용 (What)
- 로컬 `unit_*`에서 외부 노트 레포 + SQLite 구조로 바뀔 때 프론트 영향 범위를 문서화함
- 단원 목록, 문제 조회, 시험 생성 흐름에서 깨질 수 있는 계약 지점을 정리함
- 즉시 수정이 필요한 항목과 백엔드 설계 확정 후 따라가도 되는 항목을 구분함

---

## 🎯 작업 이유 (Why)
- 백엔드 저장/동기화 구조 전환이 프론트 화면과 API 계약에 주는 영향을 먼저 분리해서 보려는 목적임
- `#30`, `#31`, `#32`와 연결되는 계약 변경 포인트를 사전에 정리해 재작업을 줄이기 위함임

---

## 🔧 변경 사항 (How)
- `frontend/src/app`, `frontend/src/components`의 실제 사용 지점을 기준으로 영향도를 정리함
- frontend 문서 파일로 즉시 영향/지연 가능 항목/권장 순서를 분리해서 기록함
- 구현 코드는 변경하지 않고 분석 문서만 추가함

---

## 📁 변경 파일
- frontend/docs/source-transition-review.md

---

## 🧪 테스트 방법
1. 문서 변경 작업이라 별도 실행 테스트는 없음
2. 필요한 경우 프론트가 의존하는 API 계약 항목을 문서와 현재 소스에서 대조 확인

---

## ⚠️ 영향 범위
- 프론트 코드 실행에는 직접 영향 없음
- 후속 백엔드 계약 변경 시 `unitId`, `parts`, `questionCount`, `prompts`, `answers`, `aliases`, `keywords` 계약이 유지되는지 재확인 필요

---

## 🔥 리뷰 포인트
- 프론트가 실제로 의존하는 계약 변경 지점만 잘 분리했는지
- 백엔드 구현이 확정되기 전까지 미뤄도 되는 항목과 즉시 대응이 필요한 항목이 적절히 나뉘었는지

---

## 📸 결과 (선택)
- 문서 작업이라 별도 스크린샷 없음

---

## 🔗 관련 이슈
Closes #29

---

## ✅ 체크리스트
- [ ] 코드 실행 확인
- [ ] 기본 기능 테스트 완료
- [ ] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료