### PR TITLE
[Feature] unit_* 삭제 전 마이그레이션 체크리스트 수립

### DIFF
--- a/backend/docs/unit_removal_migration_checklist.md
+++ b/backend/docs/unit_removal_migration_checklist.md
@@ -1,0 +1,87 @@
+# Issue #40 Unit Removal Migration Checklist
+
+## Purpose
+
+This checklist defines when it is safe to delete the local `unit_*` folders.
+Deletion is the final step of the migration and must happen only after the new notes ingestion flow is live, validated, and observed in production-like conditions.
+
+## Gate Before Deletion
+
+- `#29` frontend impact review is complete.
+- `#30` backend `unit_*` dependency analysis is complete.
+- `#31` SQLite schema design is complete and implemented.
+- `#32` sync flow design is complete.
+- `#40` checklist is approved.
+- `#41` ingestion pipeline is implemented and importing real content into SQLite.
+- `active-recall-notes` CI/CD is producing the expected export artifact.
+- No runtime code path scans local markdown files as the source of truth.
+
+## Checklist
+
+### 1. Data Pipeline Readiness
+
+- [ ] `active-recall-notes` export artifact is generated from a known source commit.
+- [ ] The export bundle has a manifest with version, hash, and source commit metadata.
+- [ ] The importer in this repository can read the bundle without manual intervention.
+- [ ] Import is idempotent for the same bundle version.
+- [ ] Validation fails before any live table mutation if the bundle is malformed.
+- [ ] A successful import records the last applied bundle version.
+
+### 2. SQLite Validation
+
+- [ ] SQLite contains the full expected content set after import.
+- [ ] Canonical ids for units, parts, and questions are stable after folder removal.
+- [ ] Duplicate content ids are rejected or merged by a documented rule.
+- [ ] Existing exam, result, and stats records still resolve against the new ids.
+- [ ] Rollback to the previous good snapshot works after a failed import.
+
+### 3. API Behavior
+
+- [ ] `/units` or its replacement is backed by SQLite data, not filesystem discovery.
+- [ ] `/questions`, `/exams`, and weakness stats still behave as expected.
+- [ ] API contract tests pass against the SQLite-backed source.
+- [ ] Any response shape change is documented before the delete step begins.
+- [ ] No response field depends on folder names unless the field is intentionally preserved.
+
+### 4. Frontend Impact
+
+- [ ] Frontend signoff is complete for the current API contract.
+- [ ] If the API contract changes, frontend updates are included in the same release.
+- [ ] Exam creation, study mode, and result views work against SQLite-backed data.
+- [ ] No screen still depends on local file paths or folder-shaped assumptions.
+
+### 5. Test Hardening
+
+- [ ] Parser and loader tests no longer require local `unit_*` file paths.
+- [ ] Importer tests cover repeated runs, malformed bundles, and rollback behavior.
+- [ ] API contract tests cover the SQLite-backed source of truth.
+- [ ] E2E or integration coverage exists for the notes import and quiz read path.
+- [ ] Test fixtures are updated to use snapshot data instead of raw markdown files.
+
+### 6. Delete Gate
+
+- [ ] Deletion is done in a separate PR after the new source path is green.
+- [ ] `unit_*` folders are removed only after all runtime reads are migrated.
+- [ ] A rollback plan exists for restoring the last good snapshot and the old folders if needed.
+- [ ] Release notes clearly state that SQLite is now the source of truth.
+- [ ] A follow-up check confirms there are no remaining references to `unit_*` in runtime paths.
+
+## Rollback Criteria
+
+Do not delete `unit_*` yet if any of the following is true:
+
+- Import fails or produces partial data.
+- SQLite validation does not match the source snapshot.
+- API contract tests fail after migration.
+- Frontend behavior depends on a response shape that is not yet stable.
+- Runtime code still reads from the filesystem.
+- The last known good SQLite snapshot cannot be restored quickly.
+
+## Recommended Order
+
+1. Finish `#41` and confirm real content is flowing into SQLite.
+2. Run the validation checklist and make the importer idempotent.
+3. Verify API and frontend behavior against the new source.
+4. Harden tests and update fixtures.
+5. Remove `unit_*` folders in a final, separate PR.
+


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] unit_* 삭제 전 마이그레이션 체크리스트 수립

---

## 📌 작업 내용 (What)
- `unit_*` 폴더를 삭제하기 전에 확인해야 할 마이그레이션 체크리스트를 정리함
- 새 수집/적재 파이프라인, SQLite 검증, API 동작, 프론트 영향, 테스트 보강, 롤백 기준을 분리해서 문서화함
- 실제 삭제는 하지 않고, 삭제 전 게이트만 명확히 정의함

---

## 🎯 작업 이유 (Why)
- `unit_*`를 너무 이르게 지우면 런타임, 테스트, 프론트 계약이 동시에 흔들릴 수 있음
- 삭제를 마지막 단계의 통제된 마이그레이션으로 관리하기 위해 기준이 필요함

---

## 🔧 변경 사항 (How)
- 삭제 전 필수 조건과 체크리스트를 문서화함
- 롤백 기준과 권장 진행 순서를 추가함
- 기존 설계 문서(`#29`, `#30`, `#31`, `#32`, `#41`)와의 연결점을 반영함

---

## 📁 변경 파일
- backend/docs/unit_removal_migration_checklist.md

---

## 🧪 테스트 방법
1. 문서 내용을 열어 삭제 전 게이트와 롤백 기준이 모두 포함됐는지 확인한다.
2. `#41` 완료 전에는 `unit_*` 삭제를 진행하지 않는다는 점이 명시됐는지 확인한다.
3. 별도 코드 실행은 하지 않았다.

---

## ⚠️ 영향 범위
- 문서 작업에만 영향이 있음
- 런타임 코드, API, 프론트에는 직접 영향이 없음

---

## 🔥 리뷰 포인트
- 삭제 기준이 너무 이르지 않게 충분히 보수적으로 잡혔는지
- 다음 실행 단계(`#41` 이후 삭제 PR)로 넘기기 적절한 수준인지

---

## 📸 결과 (선택)
- 문서 작업이라 별도 결과물 스크린샷 없음

---

## 🔗 관련 이슈
Closes #40

---

## ✅ 체크리스트
- [ ] 코드 실행 확인
- [ ] 기본 기능 테스트 완료
- [ ] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료