### PR TITLE
[Feature] SQLite 운영 방식 및 배치 전략 확정

### DIFF
--- a/backend/docs/sqlite_ops_strategy.md
+++ b/backend/docs/sqlite_ops_strategy.md
@@ -1,0 +1,92 @@
+# SQLite Operations Strategy
+
+This document fixes the operational contract for how `active-recall-quiz` should run SQLite after the notes sync migration.
+It bridges the schema work in `#31`, the sync design in `#32`, and the importer path in `#41` so that `active-recall-notes` CI/CD can target a clear runtime destination.
+
+## Decision Summary
+
+- SQLite is the local source of truth for quiz runtime data.
+- The notes repository remains the content source of truth.
+- Syncing is a write operation, but normal user-facing API traffic should remain read-only.
+- The same schema should be used in local, dev, and prod; only the storage path, persistence volume, and trigger mechanism should differ.
+
+## File Location
+
+### Recommended Default
+
+- Keep the repository-local default at `backend/data/content.db` for local development and test environments.
+- Treat this as the fallback path, not the long-term production target.
+
+### Production Target
+
+- Use a persistent mounted path outside the application source tree.
+- Recommended production mount path: `/var/lib/active-recall-quiz/content.db`.
+- The app container should see the database through a volume mount, not a committed file.
+
+### Environment Separation
+
+- Local: disposable DB file in the repository workspace.
+- Dev: persistent but resettable DB volume for integration testing.
+- Prod: persistent DB volume with backup and restore policy.
+
+## Initialization
+
+- The database file should be created on first sync or first startup if it does not exist.
+- Schema creation must be deterministic and repeatable.
+- The importer should bootstrap an empty database before attempting to write content snapshots.
+- Schema migrations should be explicit, not implicit side effects of API traffic.
+
+## Runtime Placement
+
+- The actual import logic should run inside the `active-recall-quiz` backend runtime or a dedicated backend job using the same codebase.
+- It should not run in the frontend and should not run inside `active-recall-notes`.
+- User requests should read from SQLite only.
+- Content sync is the only flow that writes to the database.
+
+## Write Permissions
+
+- Normal API request handlers should not require write access except where they need to record runtime state that is already part of the backend design.
+- The sync job or sync endpoint needs write access to the SQLite file and the backup location.
+- `active-recall-notes` CI/CD should never write the database directly; it should only trigger or deliver content to the quiz backend.
+- If file permissions are tightened in production, the sync process should be the only actor with mutation rights on the DB volume.
+
+## Backup And Restore
+
+- Take a backup before applying a new snapshot.
+- Keep the last known good database available until the new import validates successfully.
+- Prefer atomic replace semantics: write to a staging file, validate, then swap into the live path.
+- Preserve enough history to restore the previous good snapshot if the new import or validation fails.
+
+## Suggested Operational Flow
+
+1. `active-recall-notes` produces a versioned export artifact.
+2. `active-recall-quiz` receives the artifact through CI/CD, dispatch, or a scheduled pull.
+3. The backend importer writes to a staging database.
+4. Validation runs against the staging database.
+5. The staging database becomes the live SQLite file only after validation succeeds.
+6. The previous live database is retained as a rollback point until the new state is confirmed.
+
+## CI/CD Target Contract
+
+The external notes repository should target a single quiz-backend ingestion surface:
+
+- authenticated trigger or artifact handoff only
+- no direct filesystem access to the SQLite volume
+- idempotent import of the same bundle version
+- explicit source commit or bundle version in every sync request
+
+This means `active-recall-notes` can safely automate content release without knowing the internal SQLite layout.
+
+## Failure Policy
+
+- If artifact validation fails, the live database must remain unchanged.
+- If the import fails midway, the partially written state must not become active.
+- If a newer bundle is invalid, the previous good snapshot stays in service.
+- Sync failures should be observable through logs that include source commit, bundle version, and failure reason.
+
+## Open Assumptions
+
+- The current repository-local default path is acceptable for local work, but production should move to a mounted volume.
+- The importer should be able to create the database file on demand.
+- `active-recall-notes` will emit a versioned artifact or dispatch event before this repository applies the import.
+


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] SQLite 운영 방식 및 배치 전략 확정

---

## 📌 작업 내용 (What)
- `active-recall-quiz`의 SQLite 운영 기준을 문서로 확정했다.
- DB 파일 위치, local/dev/prod 환경 분리, 초기 생성 방식, 백업/복구 기준, write 권한 요구사항, content sync 런타임 위치를 정리했다.
- `active-recall-notes` CI/CD가 어떤 대상을 향해야 하는지도 함께 정의했다.

---

## 🎯 작업 이유 (Why)
- `#31`, `#32`, `#41`에서 만든 설계와 구현 결과를 실제 운영 정책으로 연결하기 위해서다.
- 이후 `active-recall-notes` 쪽 자동화와 `unit_*` 제거가 같은 기준 위에서 진행되도록 하기 위함이다.

---

## 🔧 변경 사항 (How)
- 운영 경로를 repository-local 기본값과 production mounted volume으로 분리했다.
- import는 staging -> validation -> live swap 순서로 진행하도록 정리했다.
- sync 주체와 쓰기 권한 범위를 backend runtime 기준으로 문서화했다.
- notes repo CI/CD가 직접 SQLite를 만지지 않고 quiz backend ingestion surface만 대상으로 삼도록 정리했다.

---

## 📁 변경 파일
- backend/docs/sqlite_ops_strategy.md

---

## 🧪 테스트 방법
1. 문서이므로 별도 런타임 테스트를 실행하지 않았다.
2. 문서 내용을 확인해 운영 기준, 백업 정책, 권한 범위, CI/CD 대상이 일관되는지 검토했다.

---

## ⚠️ 영향 범위
- 코드 실행에는 영향이 없다.
- SQLite 운영 및 후속 CI/CD 연결 기준만 정리한다.

---

## 🔥 리뷰 포인트
- production SQLite 경로와 write 권한 범위가 현실적인지
- `active-recall-notes`가 target으로 삼아야 할 ingestion surface가 명확한지
- staging/validation/live swap 흐름이 충분히 안전한지

---

## 📸 결과 (선택)
- 문서 작업이라 별도 스크린샷 없음

---

## 🔗 관련 이슈
Closes #45

---

## ✅ 체크리스트
- [ ] 코드 실행 확인
- [ ] 기본 기능 테스트 완료
- [ ] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료