### PR TITLE
[Feature] content sync 적재 엔드포인트 실환경 검증

### DIFF
--- a/backend/docs/content_sync_runtime_validation.md
+++ b/backend/docs/content_sync_runtime_validation.md
@@ -1,0 +1,131 @@
+# Content Sync Runtime Validation
+
+This note records the runtime validation performed for `#44` against the content sync endpoint added in `#41`, using the SQLite operating contract defined in `#45`.
+
+## Validation Environment
+
+- Worktree branch: `feature/44-content-sync-runtime-validation`
+- Python runtime: `uv`-managed CPython `3.13.11`
+- Dependency install: `uv pip install --python .venv/bin/python -r backend/requirements.txt`
+- App server: `../.venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8001`
+- SQLite target path during validation: `backend/data/content.db`
+
+## Runtime Checks
+
+### 1. Server health
+
+- Request: `GET /health`
+- Result: `200 OK`
+- Response body: `{"status":"ok"}`
+
+### 2. Successful bundle import
+
+- Request: `POST /api/content-sync/bundles`
+- Bundle version used: `bundle-20260324-runtime-001`
+- Result: `200 OK`
+- Response body summary:
+  - `snapshotId = 1`
+  - `importedQuestionCount = 1`
+  - `importedDocumentCount = 1`
+  - `reusedSnapshot = false`
+
+### 3. SQLite file creation
+
+- Generated file confirmed at `backend/data/content.db`
+- SQLite query result after import:
+  - active snapshots: `1`
+  - documents stored: `1`
+  - questions stored: `1`
+
+Observed snapshot row:
+
+```json
+{
+  "id": 1,
+  "bundle_version": "bundle-20260324-runtime-001",
+  "source_commit": "abc123def456",
+  "is_active": 1
+}
+```
+
+### 4. Runtime read path after import
+
+- Request: `GET /api/units`
+- Result: imported unit summary returned from the active snapshot
+
+- Request: `GET /api/questions`
+- Result: imported question record returned from the active snapshot
+
+This confirms the runtime read path prefers SQLite-backed content once an active snapshot exists.
+
+### 5. Idempotent re-import
+
+- Same bundle posted a second time
+- Result: `200 OK`
+- Response body summary:
+  - `snapshotId = 1`
+  - `reusedSnapshot = true`
+
+This matches the intended bundle reuse behavior from `#41`.
+
+### 6. Invalid request handling
+
+- Request body omitted `manifest`
+- Result: `422 Unprocessable Content`
+- Response body:
+
+```json
+{
+  "detail": [
+    {
+      "type": "missing",
+      "loc": ["body", "manifest"],
+      "msg": "Field required",
+      "input": {
+        "documents": [],
+        "questions": []
+      }
+    }
+  ]
+}
+```
+
+## Observed Logs
+
+The server emitted the expected request-level logs for:
+
+- `GET /health -> 200`
+- `POST /api/content-sync/bundles -> 200`
+- repeated `POST /api/content-sync/bundles -> 200`
+- invalid `POST /api/content-sync/bundles -> 422`
+- `GET /api/units -> 200`
+- `GET /api/questions -> 200`
+
+These are sufficient for local validation, but production sync should add structured logging around bundle version, source commit, and failure reason.
+
+## CI/CD Readiness Assessment
+
+What is ready now:
+
+- The backend can receive a content bundle over HTTP.
+- A successful request creates the SQLite file if it does not already exist.
+- Imported content becomes the active runtime source.
+- Reposting the same bundle version is idempotent.
+- Invalid payloads fail fast with schema validation.
+
+What still needs attention before production CI/CD:
+
+- The endpoint is currently unauthenticated.
+- There is no staging DB swap or backup/restore flow yet.
+- Validation is local-only; deploy-target path and secret handling still need environment-specific wiring.
+
+## Conclusion
+
+`#41` is runtime-viable for a first end-to-end sync in local validation:
+
+- app starts successfully
+- content sync writes SQLite
+- runtime reads the imported snapshot
+- malformed requests return `422`
+
+This is enough to continue toward external CI/CD integration, but production rollout should add authentication and rollout safeguards before `active-recall-notes` pushes data automatically.

--- a/backend/tests/test_content_sync.py
+++ b/backend/tests/test_content_sync.py
@@ -85,6 +85,16 @@ def test_imported_bundle_becomes_runtime_source(isolated_sqlite: None) -> None:
     assert summaries[0].questionCount == 2
 
 
+def test_import_creates_sqlite_file(isolated_sqlite: None) -> None:
+    sqlite_path = settings.sqlite_path
+
+    assert not sqlite_path.exists()
+
+    ContentSyncService().import_bundle(_sample_bundle())
+
+    assert sqlite_path.exists()
+
+
 def test_import_reuses_existing_snapshot_for_same_bundle_version(isolated_sqlite: None) -> None:
     first = ContentSyncService().import_bundle(_sample_bundle())
     second = ContentSyncService().import_bundle(_sample_bundle())


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] content sync 적재 엔드포인트 실환경 검증

---

## 📌 작업 내용 (What)
- `content-sync` 적재 엔드포인트를 uv 기반 Python 3.13 런타임에서 실제로 검증함
- 성공 요청, 재요청 idempotency, 422 실패 응답, SQLite 파일 생성과 런타임 조회 반영 여부를 확인함
- 검증 결과를 문서로 남기고 SQLite 파일 생성 회귀 테스트를 보강함

---

## 🎯 작업 이유 (Why)
- `active-recall-notes` CI/CD를 연결하기 전에 수신 측인 `active-recall-quiz`가 실제 SQLite 생성과 적재를 처리할 수 있는지 확인해야 함
- 로컬 검증 결과를 문서화해 이후 운영 연결과 리뷰 기준을 명확히 하기 위함

---

## 🔧 변경 사항 (How)
- `uv`로 Python 3.13 가상환경을 만들고 backend 의존성을 설치한 뒤 `uvicorn`으로 서버를 실행함
- `POST /api/content-sync/bundles` 요청으로 SQLite 파일 생성과 적재를 검증함
- 동일 번들 재전송 시 `reusedSnapshot=true`가 반환되는지 확인함
- `GET /api/units`, `GET /api/questions`로 active snapshot 읽기 경로를 확인함
- `manifest` 누락 요청으로 `422` 응답을 확인함
- 검증 내용을 문서화하고 SQLite 파일 생성 회귀 테스트를 추가함

---

## 📁 변경 파일
- backend/docs/content_sync_runtime_validation.md
- backend/tests/test_content_sync.py

---

## 🧪 테스트 방법
1. `uv venv`로 Python 3.13 환경을 준비한다.
2. `UV_CACHE_DIR=/tmp/active_recall_quiz-44/.uv-cache uv pip install --python .venv/bin/python -r backend/requirements.txt`를 실행한다.
3. `../.venv/bin/uvicorn app.main:app --host 127.0.0.1 --port 8001`로 서버를 실행한다.
4. `curl -s http://127.0.0.1:8001/health`가 `{"status":"ok"}`를 반환하는지 확인한다.
5. `POST /api/content-sync/bundles`로 샘플 번들을 보내 SQLite 생성과 적재를 확인한다.
6. `UV_CACHE_DIR=/tmp/active_recall_quiz-44/.uv-cache PYTHONPATH=backend .venv/bin/python -m pytest backend/tests/test_content_sync.py`를 실행한다.

---

## ⚠️ 영향 범위
- backend 검증 문서와 content sync 테스트에만 영향이 있음
- 앱 런타임 로직 자체를 변경하지는 않음
- 생성된 SQLite 파일과 임시 응답 파일은 커밋에 포함하지 않음

---

## 🔥 리뷰 포인트
- runtime validation 문서가 실제 확인한 결과를 충분히 전달하는지
- SQLite 파일 생성 회귀 테스트가 적절한 최소 보강인지
- CI/CD 연결 전 남은 리스크 정리가 타당한지

---

## 📸 결과 (선택)
- 성공 import 응답: `{"snapshotId":1,"importedBundleVersion":"bundle-20260324-runtime-001","importedQuestionCount":1,"importedDocumentCount":1,"reusedSnapshot":false}`
- 재요청 응답: `reusedSnapshot=true`
- 실패 응답: `422 Unprocessable Content`
- 테스트 결과: `3 passed in 0.12s`

---

## 🔗 관련 이슈
Closes #44

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료