### PR TITLE
[Feature] content sync 엔드포인트 토큰 인증 추가

### DIFF
--- a/backend/app/api/routes_content_sync.py
+++ b/backend/app/api/routes_content_sync.py
@@ -1,5 +1,8 @@
-from fastapi import APIRouter
+from typing import Annotated
 
+from fastapi import APIRouter, Header, HTTPException, status
+
+from app.core.config import settings
 from app.schemas.content_sync import ContentBundleImportRequest, ContentBundleImportResult
 from app.services.content_sync_service import ContentSyncService
 
@@ -7,5 +10,26 @@ router = APIRouter(tags=["content-sync"])
 
 
 @router.post("/content-sync/bundles", response_model=ContentBundleImportResult)
-def import_content_bundle(payload: ContentBundleImportRequest) -> ContentBundleImportResult:
+def import_content_bundle(
+    payload: ContentBundleImportRequest,
+    content_sync_token: Annotated[str | None, Header(alias="X-Content-Sync-Token")] = None,
+) -> ContentBundleImportResult:
+    if not settings.content_sync_token:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Content sync token is not configured.",
+        )
+
+    if content_sync_token is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Missing content sync token.",
+        )
+
+    if content_sync_token != settings.content_sync_token:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid content sync token.",
+        )
+
     return ContentSyncService().import_bundle(payload)

--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -7,6 +8,7 @@ class Settings(BaseModel):
     app_root: Path = Path(__file__).resolve().parents[3]
     content_glob: str = "unit_*/*.md"
     sqlite_path: Path = app_root / "backend" / "data" / "content.db"
+    content_sync_token: str | None = os.getenv("CONTENT_SYNC_TOKEN")
 
 
 settings = Settings()

--- a/backend/tests/test_content_sync.py
+++ b/backend/tests/test_content_sync.py
@@ -1,7 +1,9 @@
 from pathlib import Path
 
 import pytest
+from fastapi import HTTPException
 
+from app.api.routes_content_sync import import_content_bundle
 from app.core.config import settings
 from app.schemas.content_sync import (
     ContentBundleImportRequest,
@@ -95,3 +97,47 @@ def test_import_reuses_existing_snapshot_for_same_bundle_version(isolated_sqlite
     assert second.reusedSnapshot is True
     assert second.snapshotId == first.snapshotId
     assert len(questions) == 2
+
+
+@pytest.fixture()
+def content_sync_token() -> None:
+    original_token = settings.content_sync_token
+    settings.content_sync_token = "test-sync-token"
+    yield
+    settings.content_sync_token = original_token
+
+
+def test_content_sync_requires_token(isolated_sqlite: None, content_sync_token: None) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        import_content_bundle(_sample_bundle())
+
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.detail == "Missing content sync token."
+
+
+def test_content_sync_rejects_invalid_token(isolated_sqlite: None, content_sync_token: None) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        import_content_bundle(_sample_bundle(), content_sync_token="wrong-token")
+
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Invalid content sync token."
+
+
+def test_content_sync_accepts_valid_token(isolated_sqlite: None, content_sync_token: None) -> None:
+    response = import_content_bundle(_sample_bundle(), content_sync_token="test-sync-token")
+
+    assert response.importedQuestionCount == 2
+
+
+def test_content_sync_returns_503_when_server_token_is_unset(isolated_sqlite: None) -> None:
+    original_token = settings.content_sync_token
+    settings.content_sync_token = None
+
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            import_content_bundle(_sample_bundle(), content_sync_token="any-token")
+    finally:
+        settings.content_sync_token = original_token
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == "Content sync token is not configured."


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] content sync 엔드포인트 토큰 인증 추가

---

## 📌 작업 내용 (What)
- content sync 번들 적재 엔드포인트에 토큰 인증을 추가함
- 서버 설정에서 `CONTENT_SYNC_TOKEN`을 읽도록 확장함
- 정상/누락/오류/미설정 토큰 케이스를 테스트로 검증함

---

## 🎯 작업 이유 (Why)
- `active-recall-notes` GitHub Actions가 호출하는 적재 엔드포인트를 최소한의 shared secret으로 보호하기 위함
- 임의 요청으로 SQLite 데이터가 오염되는 위험을 줄이기 위함

---

## 🔧 변경 사항 (How)
- `X-Content-Sync-Token` 헤더를 사용해 요청 토큰을 받도록 구현함
- 서버 토큰 미설정 시 `503`, 토큰 누락 시 `401`, 토큰 불일치 시 `403`을 반환하도록 분기함
- 기존 content sync 서비스 로직은 유지하고 라우트에서만 인증을 검증하도록 최소 침습으로 반영함

---

## 📁 변경 파일
- backend/app/api/routes_content_sync.py
- backend/app/core/config.py
- backend/tests/test_content_sync.py

---

## 🧪 테스트 방법
1. `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/test_content_sync.py` 실행
2. `PYTHONPATH=backend python3 -m compileall backend/app backend/tests/test_content_sync.py` 실행
3. 토큰 누락/불일치/정상/미설정 케이스가 각각 기대 상태 코드로 처리되는지 확인

---

## ⚠️ 영향 범위
- `/api/content-sync/bundles` 엔드포인트 호출 시 토큰 헤더가 필수로 바뀜
- 기존 시험/학습/질문 조회 API에는 영향 없음

---

## 🔥 리뷰 포인트
- `X-Content-Sync-Token` 헤더 방식이 notes 저장소 GitHub Actions와 잘 맞는지
- 토큰 미설정 시 fail-closed(`503`) 처리 방식이 운영 의도에 맞는지

---

## 📸 결과 (선택)
- 별도 스크린샷 없음

---

## 🔗 관련 이슈
Closes #48

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료