### PR TITLE
[Feature] SQLite 경로를 env 기반으로 전환해 Railway Volume 대응

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -1,13 +1,18 @@
 import os
 from pathlib import Path
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+
+
+def _default_sqlite_path() -> Path:
+    app_root = Path(__file__).resolve().parents[3]
+    return Path(os.getenv("SQLITE_PATH", str(app_root / "backend" / "data" / "content.db")))
 
 
 class Settings(BaseModel):
     app_root: Path = Path(__file__).resolve().parents[3]
     content_glob: str = "unit_*/*.md"
-    sqlite_path: Path = app_root / "backend" / "data" / "content.db"
+    sqlite_path: Path = Field(default_factory=_default_sqlite_path)
     content_sync_token: str | None = os.getenv("CONTENT_SYNC_TOKEN")
 
 

--- a/backend/docs/sqlite_ops_strategy.md
+++ b/backend/docs/sqlite_ops_strategy.md
@@ -16,11 +16,13 @@ It bridges the schema work in `#31`, the sync design in `#32`, and the importer 
 
 - Keep the repository-local default at `backend/data/content.db` for local development and test environments.
 - Treat this as the fallback path, not the long-term production target.
+- Override the runtime path with `SQLITE_PATH` when deploying to an external volume.
 
 ### Production Target
 
 - Use a persistent mounted path outside the application source tree.
 - Recommended production mount path: `/var/lib/active-recall-quiz/content.db`.
+- Railway-friendly example: `SQLITE_PATH=/data/content.db`
 - The app container should see the database through a volume mount, not a committed file.
 
 ### Environment Separation
@@ -89,4 +91,3 @@ This means `active-recall-notes` can safely automate content release without kno
 - The current repository-local default path is acceptable for local work, but production should move to a mounted volume.
 - The importer should be able to create the database file on demand.
 - `active-recall-notes` will emit a versioned artifact or dispatch event before this repository applies the import.
-

--- a/backend/tests/test_content_sync.py
+++ b/backend/tests/test_content_sync.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi import HTTPException
 
 from app.api.routes_content_sync import import_content_bundle
-from app.core.config import settings
+from app.core.config import Settings, settings
 from app.schemas.content_sync import (
     ContentBundleImportRequest,
     ContentManifest,
@@ -151,3 +151,12 @@ def test_content_sync_returns_503_when_server_token_is_unset(isolated_sqlite: No
 
     assert exc_info.value.status_code == 503
     assert exc_info.value.detail == "Content sync token is not configured."
+
+
+def test_settings_reads_sqlite_path_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    expected_path = "/data/content.db"
+    monkeypatch.setenv("SQLITE_PATH", expected_path)
+
+    configured = Settings()
+
+    assert configured.sqlite_path == Path(expected_path)


### PR DESCRIPTION
## 🧩 PR 제목
[Feature] SQLite 경로를 env 기반으로 전환해 Railway Volume 대응

---

## 📌 작업 내용 (What)
- SQLite 파일 경로를 환경변수 `SQLITE_PATH`로 override할 수 있게 변경함
- 로컬 기본 경로 `backend/data/content.db`는 그대로 유지함
- Railway Volume에 맞춰 `/data/content.db` 같은 절대 경로를 설정할 수 있도록 문서와 테스트를 보강함

---

## 🎯 작업 이유 (Why)
- Railway에 backend를 배포할 때 SQLite를 영속 볼륨 경로에 저장할 수 있어야 함
- 로컬 개발 환경과 운영 환경이 서로 다른 DB 경로를 무리 없이 사용할 수 있어야 함

---

## 🔧 변경 사항 (How)
- `Settings.sqlite_path`를 고정 Path 대신 `Field(default_factory=...)`로 바꿔 런타임 env를 읽도록 구현함
- `SQLITE_PATH`가 없을 때는 기존 저장소 내부 경로를 fallback으로 유지함
- 테스트에 env override 케이스를 추가하고 운영 문서에 Railway 예시 경로를 반영함

---

## 📁 변경 파일
- backend/app/core/config.py
- backend/tests/test_content_sync.py
- backend/docs/sqlite_ops_strategy.md

---

## 🧪 테스트 방법
1. `PYTHONPATH=backend backend/.venv/bin/python -m pytest backend/tests/test_content_sync.py` 실행
2. `PYTHONPATH=backend python3 -m compileall backend/app backend/tests/test_content_sync.py` 실행
3. `SQLITE_PATH=/data/content.db` 같은 환경변수 값이 `Settings()`에 반영되는지 테스트로 확인

---

## ⚠️ 영향 범위
- backend의 SQLite 파일 경로 해석 방식에만 영향이 있음
- `SQLITE_PATH`를 설정하지 않으면 기존 동작을 유지함

---

## 🔥 리뷰 포인트
- `Field(default_factory=...)` 방식이 런타임 env override 요구사항에 맞는지
- Railway Volume 경로 적용 시 로컬 fallback 동작을 깨지 않는지

---

## 📸 결과 (선택)
- 문서/설정 변경 작업이라 별도 스크린샷 없음

---

## 🔗 관련 이슈
Closes #51

---

## ✅ 체크리스트
- [x] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료