### PR TITLE
[Fix] .gitignore 충돌로 frontend lib 추적 복구

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,7 +89,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,64 @@
+import { ExamDetail, GradingResult, QuestionDetail, UnitSummary } from "@/lib/types";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://127.0.0.1:8000/api";
+
+async function request<T>(path: string, init?: RequestInit): Promise<T> {
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {})
+    },
+    cache: "no-store"
+  });
+
+  if (!response.ok) {
+    throw new Error(`API request failed: ${response.status}`);
+  }
+
+  return (await response.json()) as T;
+}
+
+export function getUnits(): Promise<UnitSummary[]> {
+  return request<UnitSummary[]>("/units");
+}
+
+export function getQuestions(): Promise<QuestionDetail[]> {
+  return request<QuestionDetail[]>("/questions");
+}
+
+type CreateExamPayload = {
+  unitIds?: string[];
+  parts?: string[];
+  questionCount?: number;
+  mode?: "study" | "exam";
+  shuffle?: boolean;
+};
+
+export function createExam(payload?: CreateExamPayload): Promise<ExamDetail> {
+  return request<ExamDetail>("/exams", {
+    method: "POST",
+    body: JSON.stringify({
+      unitIds: payload?.unitIds ?? [],
+      parts: payload?.parts ?? [],
+      questionCount: payload?.questionCount ?? 5,
+      mode: payload?.mode ?? "exam",
+      shuffle: payload?.shuffle ?? false
+    })
+  });
+}
+
+export function getExam(examId: string): Promise<ExamDetail> {
+  return request<ExamDetail>(`/exams/${examId}`);
+}
+
+export function submitExam(examId: string, answers: { questionId: string; responseText: string }[]): Promise<GradingResult> {
+  return request<GradingResult>(`/exams/${examId}/submit`, {
+    method: "POST",
+    body: JSON.stringify({ answers })
+  });
+}
+
+export function getExamResult(examId: string): Promise<GradingResult> {
+  return request<GradingResult>(`/exams/${examId}/result`);
+}

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -1,0 +1,78 @@
+export type QuestionType = "short_answer" | "list_answer";
+
+export type UnitSummary = {
+  unitId: string;
+  title: string;
+  parts: string[];
+  questionCount: number;
+};
+
+export type QuestionDetail = {
+  questionId: string;
+  unitId: string;
+  part: string;
+  title?: string | null;
+  type: QuestionType;
+  prompts: string[];
+  answers: string[];
+  aliases: string[];
+  keywords: string[];
+  warnings: string[];
+  sourcePath: string;
+  sourceLine: number;
+};
+
+export type ExamQuestion = {
+  questionId: string;
+  unitId: string;
+  part: string;
+  type: QuestionType;
+  prompts: string[];
+  answersSnapshot: string[];
+  aliasesSnapshot: string[];
+  keywordsSnapshot: string[];
+  maxScore: number;
+};
+
+export type ExamDetail = {
+  examId: string;
+  mode: "study" | "exam";
+  createdAt: string;
+  unitIds: string[];
+  parts: string[];
+  questionCount: number;
+  questions: ExamQuestion[];
+};
+
+export type QuestionGradingResult = {
+  questionId: string;
+  type: QuestionType;
+  isCorrect: boolean;
+  earnedScore: number;
+  maxScore: number;
+  userAnswer: string;
+  expectedAnswers: string[];
+  matchedKeywords: string[];
+  missingKeywords: string[];
+  feedback: string;
+};
+
+export type GradingResult = {
+  examId: string;
+  score: number;
+  total: number;
+  submittedAt: string;
+  results: QuestionGradingResult[];
+};
+
+export type WrongNoteEntry = {
+  id: string;
+  savedAt: string;
+  examId: string;
+  questionId: string;
+  type: QuestionType;
+  userAnswer: string;
+  expectedAnswers: string[];
+  feedback: string;
+  missingKeywords: string[];
+};

--- a/frontend/src/lib/wrong-note-storage.ts
+++ b/frontend/src/lib/wrong-note-storage.ts
@@ -1,0 +1,59 @@
+import { GradingResult, WrongNoteEntry } from "@/lib/types";
+
+export const WRONG_NOTE_STORAGE_KEY = "active-recall-quiz/wrong-notes";
+
+function canUseStorage(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function readWrongNotes(): WrongNoteEntry[] {
+  if (!canUseStorage()) {
+    return [];
+  }
+
+  const rawValue = window.localStorage.getItem(WRONG_NOTE_STORAGE_KEY);
+  if (!rawValue) {
+    return [];
+  }
+
+  try {
+    const parsed = JSON.parse(rawValue) as WrongNoteEntry[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeWrongNotes(entries: WrongNoteEntry[]): void {
+  if (!canUseStorage()) {
+    return;
+  }
+
+  window.localStorage.setItem(WRONG_NOTE_STORAGE_KEY, JSON.stringify(entries));
+}
+
+export function appendWrongNotesFromResult(result: GradingResult): number {
+  const wrongEntries = result.results
+    .filter((item) => !item.isCorrect)
+    .map<WrongNoteEntry>((item) => ({
+      id: `${result.examId}:${item.questionId}`,
+      savedAt: result.submittedAt,
+      examId: result.examId,
+      questionId: item.questionId,
+      type: item.type,
+      userAnswer: item.userAnswer,
+      expectedAnswers: item.expectedAnswers,
+      feedback: item.feedback,
+      missingKeywords: item.missingKeywords
+    }));
+
+  if (wrongEntries.length === 0) {
+    return 0;
+  }
+
+  const existingEntries = readWrongNotes();
+  const entryMap = new Map(existingEntries.map((entry) => [entry.id, entry]));
+  wrongEntries.forEach((entry) => entryMap.set(entry.id, entry));
+  writeWrongNotes(Array.from(entryMap.values()).sort((left, right) => right.savedAt.localeCompare(left.savedAt)));
+  return wrongEntries.length;
+}


### PR DESCRIPTION
## 🧩 PR 제목
[Fix] .gitignore 충돌로 frontend lib 추적 복구

---

## 📌 작업 내용 (What)
- 루트 `.gitignore`의 과도한 `lib/` 규칙을 좁혀 `frontend/src/lib/*`가 Git 추적에서 누락되지 않도록 복구함
- `frontend/src/lib/api.ts`, `frontend/src/lib/types.ts`, `frontend/src/lib/wrong-note-storage.ts`를 정상 추적 대상으로 되돌림

---

## 🎯 작업 이유 (Why)
- Vercel 빌드에서 `@/lib/api` 및 관련 alias를 찾지 못해 프론트 배포가 실패했기 때문
- 프론트 빌드에 필요한 lib 파일이 저장소에 포함되어야 했음

---

## 🔧 변경 사항 (How)
- `.gitignore`의 `lib/` 패턴을 `/lib/`로 변경해 루트 디렉터리만 무시하도록 조정함
- `frontend/src/lib/*` 파일을 Git 추적 대상으로 복구함

---

## 📁 변경 파일
- .gitignore
- frontend/src/lib/api.ts
- frontend/src/lib/types.ts
- frontend/src/lib/wrong-note-storage.ts

---

## 🧪 테스트 방법
1. `git check-ignore -v frontend/src/lib/api.ts frontend/src/lib/types.ts frontend/src/lib/wrong-note-storage.ts`로 더 이상 ignore되지 않는지 확인
2. `git status --short`로 프론트 lib 파일이 untracked로 보이는지 확인
3. Vercel 재배포 후 `@/lib/api` module not found 오류가 사라지는지 확인

---

## ⚠️ 영향 범위
- 프론트 배포 및 빌드 설정에만 영향
- backend, shared, README, AGENTS, .github에는 영향 없음

---

## 🔥 리뷰 포인트
- `.gitignore` 패턴을 루트 기준으로 좁힌 변경이 의도한 범위만 영향 주는지
- 프론트 `src/lib` 파일이 실제로 버전 관리 가능해졌는지

---

## 📸 결과 (선택)
- 별도 스크린샷 없음

---

## 🔗 관련 이슈
Closes #55

---

## ✅ 체크리스트
- [ ] 코드 실행 확인
- [x] 기본 기능 테스트 완료
- [x] 예외 케이스 고려
- [x] 기존 기능 영향 없음
- [x] 문서화 완료